### PR TITLE
fix:2 ユーザー登録のTOCTOU競合状態を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 .claude
 scripts
+issue-plan.md

--- a/apps/api/src/routes/auth/register.ts
+++ b/apps/api/src/routes/auth/register.ts
@@ -7,21 +7,11 @@ import { vValidator } from "@hono/valibot-validator";
 import { validationHook } from "@/lib/validators";
 import { nanoid } from "nanoid";
 import bcrypt from "bcrypt";
-import { eq } from "drizzle-orm";
 
 const register = new Hono();
 
 register.post("/", vValidator("json", registerSchema, validationHook), async (c) => {
   const { email, password } = c.req.valid("json");
-
-  const existing = await db.query.users.findFirst({
-    where: eq(users.email, email),
-    columns: { id: true },
-  });
-
-  if (existing) {
-    throw new HTTPException(409, { message: "このメールアドレスはすでに使用されています" });
-  }
 
   const passwordHash = await bcrypt.hash(password, 10);
 


### PR DESCRIPTION
## Summary
- ユーザー登録時の TOCTOU (Time-of-check to time-of-use) 競合状態を修正
- 事前の存在確認（`findFirst`）を削除し、DB の UNIQUE 制約のみに依存する形に変更
- これにより「確認→操作」間に別リクエストが割り込む競合状態を防止

## Test plan
- [ ] 新規ユーザー登録が正常に動作すること
- [ ] 既存のメールアドレスで登録しようとすると 409 エラーが返ること

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)