### PR TITLE
fix: .returning() の配列チェック漏れ＆パスパラメータバリデーション追加

### DIFF
--- a/apps/api/src/lib/validators/cat.ts
+++ b/apps/api/src/lib/validators/cat.ts
@@ -21,3 +21,13 @@ export const updateCatSchema = v.pipe(
 );
 
 export type UpdateCatInput = v.InferInput<typeof updateCatSchema>;
+
+// nanoid のデフォルト長は 21 文字、許可文字は A-Za-z0-9_-
+export const catIdParamSchema = v.object({
+  id: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.maxLength(30),
+    v.regex(/^[A-Za-z0-9_-]+$/, "無効なIDフォーマットです")
+  ),
+});

--- a/apps/api/src/routes/cats/create.ts
+++ b/apps/api/src/routes/cats/create.ts
@@ -23,6 +23,11 @@ create.post("/", vValidator("json", createCatSchema, validationHook), async (c) 
         ...body,
       })
       .returning();
+
+    if (!cat) {
+      throw new HTTPException(500, { message: "猫の作成に失敗しました" });
+    }
+
     return c.json(cat, 201);
   } catch (error) {
     console.error("猫の作成に失敗しました:", error);

--- a/apps/api/src/routes/cats/delete.ts
+++ b/apps/api/src/routes/cats/delete.ts
@@ -1,32 +1,39 @@
 import { db } from "@/db";
+import { catIdParamSchema } from "@/lib/validators/cat";
+import { validationHook } from "@/lib/validators";
 import { cats } from "@repo/db";
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { vValidator } from "@hono/valibot-validator";
 import type { HonoEnv } from "@/lib/types";
 
 const deleteCat = new Hono<HonoEnv>();
 
-deleteCat.delete("/:id", async (c) => {
-  const userId = c.get("userId");
-  const id = c.req.param("id");
+deleteCat.delete(
+  "/:id",
+  vValidator("param", catIdParamSchema, validationHook),
+  async (c) => {
+    const userId = c.get("userId");
+    const { id } = c.req.valid("param");
 
-  try {
-    const [deleted] = await db
-      .delete(cats)
-      .where(and(eq(cats.id, id), eq(cats.ownerId, userId)))
-      .returning();
+    try {
+      const [deleted] = await db
+        .delete(cats)
+        .where(and(eq(cats.id, id), eq(cats.ownerId, userId)))
+        .returning();
 
-    if (!deleted) {
-      throw new HTTPException(404, { message: "猫が見つかりません" });
+      if (!deleted) {
+        throw new HTTPException(404, { message: "猫が見つかりません" });
+      }
+
+      return c.body(null, 204);
+    } catch (err) {
+      if (err instanceof HTTPException) throw err;
+      console.error("猫の削除に失敗しました:", err);
+      throw new HTTPException(500, { message: "猫の削除に失敗しました" });
     }
-
-    return c.body(null, 204);
-  } catch (err) {
-    if (err instanceof HTTPException) throw err;
-    console.error("猫の削除に失敗しました:", err);
-    throw new HTTPException(500, { message: "猫の削除に失敗しました" });
   }
-});
+);
 
 export { deleteCat };

--- a/apps/api/src/routes/cats/detail.ts
+++ b/apps/api/src/routes/cats/detail.ts
@@ -1,15 +1,18 @@
 import { db } from "@/db";
+import { catIdParamSchema } from "@/lib/validators/cat";
+import { validationHook } from "@/lib/validators";
 import { cats } from "@repo/db";
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { vValidator } from "@hono/valibot-validator";
 import type { HonoEnv } from "@/lib/types";
 
 const detail = new Hono<HonoEnv>();
 
-detail.get("/:id", async (c) => {
+detail.get("/:id", vValidator("param", catIdParamSchema, validationHook), async (c) => {
   const userId = c.get("userId");
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const cat = await db.query.cats.findFirst({
     where: and(eq(cats.id, id), eq(cats.ownerId, userId)),

--- a/apps/api/src/routes/cats/update.ts
+++ b/apps/api/src/routes/cats/update.ts
@@ -1,5 +1,5 @@
 import { db } from "@/db";
-import { updateCatSchema } from "@/lib/validators/cat";
+import { updateCatSchema, catIdParamSchema } from "@/lib/validators/cat";
 import { cats } from "@repo/db";
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
@@ -10,30 +10,35 @@ import type { HonoEnv } from "@/lib/types";
 
 const update = new Hono<HonoEnv>();
 
-update.patch("/:id", vValidator("json", updateCatSchema, validationHook), async (c) => {
-  const userId = c.get("userId");
-  const id = c.req.param("id");
-  const body = c.req.valid("json");
+update.patch(
+  "/:id",
+  vValidator("param", catIdParamSchema, validationHook),
+  vValidator("json", updateCatSchema, validationHook),
+  async (c) => {
+    const userId = c.get("userId");
+    const { id } = c.req.valid("param");
+    const body = c.req.valid("json");
 
-  try {
-    const [updated] = await db
-      .update(cats)
-      .set({
-        ...body,
-      })
-      .where(and(eq(cats.id, id), eq(cats.ownerId, userId)))
-      .returning();
+    try {
+      const [updated] = await db
+        .update(cats)
+        .set({
+          ...body,
+        })
+        .where(and(eq(cats.id, id), eq(cats.ownerId, userId)))
+        .returning();
 
-    if (!updated) {
-      throw new HTTPException(404, { message: "猫が見つかりません" });
+      if (!updated) {
+        throw new HTTPException(404, { message: "猫が見つかりません" });
+      }
+
+      return c.json(updated);
+    } catch (err) {
+      if (err instanceof HTTPException) throw err;
+      console.error("猫の更新に失敗しました:", err);
+      throw new HTTPException(500, { message: "猫の更新に失敗しました" });
     }
-
-    return c.json(updated);
-  } catch (err) {
-    if (err instanceof HTTPException) throw err;
-    console.error("猫の更新に失敗しました:", err);
-    throw new HTTPException(500, { message: "猫の更新に失敗しました" });
   }
-});
+);
 
 export { update };


### PR DESCRIPTION
## Summary
- `create.ts` に `.returning()` 結果の存在チェックを追加（堅牢性向上）
- `detail.ts`、`update.ts`、`delete.ts` にパスパラメータバリデーションを追加
- `catIdParamSchema` を `validators/cat.ts` に追加（nanoid形式のIDフォーマットを検証）

## Test plan
- [ ] 正常な猫IDで各エンドポイント（GET/PATCH/DELETE /api/cats/:id）が動作することを確認
- [ ] 不正なIDフォーマット（空文字、特殊文字、長すぎる文字列）でリクエストした場合、400エラーが返ることを確認
- [ ] 猫の作成（POST /api/cats）が正常に動作することを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)